### PR TITLE
Hotfix/fresh clone errors

### DIFF
--- a/Server/lib/getLogger.ts
+++ b/Server/lib/getLogger.ts
@@ -1,9 +1,13 @@
-import {mkdirpSync} from "fs-extra-promise";
+import {mkdirpSync, mkdirsSync} from "fs-extra-promise";
 import * as bunyan from "bunyan";
 import * as callsiteRecord from "callsite-record";
+import {existsSync} from "fs";
 
 const loggerExport = {
     create(name) {
+        // create output directory if it doesn't exist
+        if (!existsSync("logs")) mkdirsSync("logs");
+
         return bunyan.createLogger({
             name,
 

--- a/Server/lib/storage/DatabaseManager.ts
+++ b/Server/lib/storage/DatabaseManager.ts
@@ -3,6 +3,8 @@ import * as fs from "fs-extra-promise";
 import {Logger} from "../getLogger";
 import DatabaseGetter from "./getter/DatabaseGetter";
 import UserGetter from "./getter/UserGetter";
+import {existsAsync, mkdirsAsync, mkdirsSync} from "fs-extra-promise";
+import {existsSync} from "fs";
 
 const logger = Logger.create("storage/DatabaseManager");
 
@@ -74,6 +76,8 @@ export default class DatabaseManager {
         let pathName = path.join(this.dataDirectory, name);
         logger.debug(`Directory is ${pathName} (root directory is ${this.dataDirectory})`);
 
+        if (!existsSync(pathName)) mkdirsSync(pathName);
+
         return new DatabaseGetter(pathName);
     }
 
@@ -84,6 +88,8 @@ export default class DatabaseManager {
 
         const pathName = path.join(this.dataDirectory, name);
         logger.debug("Directory is", pathName, "( root directory is", this.dataDirectory, ")");
+
+        if (!existsSync(pathName)) mkdirsSync(pathName);
 
         return new UserGetter(pathName);
     }


### PR DESCRIPTION
This PR fixes #8 by creating the `logs` directory and database directories if they do not exist on startup, to prevent errors on startup.