### PR TITLE
Hotfix/repo/get name

### DIFF
--- a/Server/lib/Git/GitServer.ts
+++ b/Server/lib/Git/GitServer.ts
@@ -8,7 +8,7 @@ import {
     existsAsync,
     mkdirpAsync,
     moveAsync,
-    readdirAsync,
+    readdirAsync, readFileAsync,
     statAsync,
     writeFileAsync
 } from "fs-extra-promise";
@@ -397,6 +397,13 @@ export default class GitServer extends EventEmitter {
         );
 
         return fileList.concat(uniqueFolderList);
+    }
+
+    getRepositoryName(assumedName: string) {
+        const repoName = GitServer.getRepositoryName(assumedName);
+        const repoDescriptionPath = path.join(this.dataDirectory, repoName, "description");
+
+        return readFileAsync(repoDescriptionPath, "utf8");
     }
 }
 

--- a/Server/lib/index.ts
+++ b/Server/lib/index.ts
@@ -20,7 +20,7 @@ import LocalState from "./tool/LocalState";
 import User from "./security/User";
 import {
     RepositoryCreate, RepositoryFileContents,
-    RepositoryGetFiles, RepositoryList,
+    RepositoryGetFiles, RepositoryGetName, RepositoryList,
     Resource,
     UsernameFieldUpdate
 } from "./responder-types";
@@ -291,6 +291,10 @@ const run = async function() {
             return {
                 contents: await gitServer.readFile(data["repository"], data["hash"], data["file"])
             }
+        });
+
+        authClient.respondWithoutUserCheck(RepositoryGetName, "repository:get-name", async (authCode, data) => {
+            return await gitServer.getRepositoryName(data["assumedName"])
         });
 
         authClient.respondWithoutUserCheck(RepositoryList, "repository:list", (authCode, data) => {

--- a/Server/lib/responder-types.ts
+++ b/Server/lib/responder-types.ts
@@ -36,6 +36,10 @@ export const RepositoryFileContents = Record({
     file: String
 });
 
+export const RepositoryGetName = Record({
+    assumedName: String
+});
+
 export const Resource = Record({
     path: String
 });


### PR DESCRIPTION
This fixes #10 by adding the `repository:get-name` getter in the backend.

This gets the name from the `description` file in the repository folder.