### PR TITLE
Adds more styling to repository name

### DIFF
--- a/Client/src/scss/pages/repository.scss
+++ b/Client/src/scss/pages/repository.scss
@@ -7,8 +7,13 @@
     border: 1px solid #c8c8c8;
     border-radius: 4px 4px 0 0;
 
+    display: block;
+
     font-size: 1.2em;
     font-weight: 600;
+
+    color: black;
+    text-decoration: none;
 }
 
 #buttons {


### PR DESCRIPTION
It seemed like the repository name element had been converted to a link, however it was not changed back to be `display: block` with HREF styles removed.